### PR TITLE
Update the open source homebrew installation docs

### DIFF
--- a/source/opensource.rst
+++ b/source/opensource.rst
@@ -177,7 +177,7 @@ The following are the instructions for compiling on OS X, tested on OS X 10.9.5 
 Using Homebrew
 .................
 
-  * brew tap homebrew/science
+  * brew update
   * brew install openalpr
 
 Compiling OpenALPR Manually


### PR DESCRIPTION
The homebrew package has been removed from the homebrew/science tap to homebrew/core as the former is no longer maintained

migrating to homebrew-core: https://github.com/Homebrew/homebrew-core/pull/67822
remove from homebrew-science: https://github.com/brewsci/homebrew-science/pull/265